### PR TITLE
ci(test): bump to use newer ubuntu-24.04 rather than ubuntu-20.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,8 @@ jobs:
             runs-on: ubuntu-24.04
             image: python:3.5
           - python-version: "3.6"
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-24.04
+            image: python:3.6
           - python-version: "3.7"
             runs-on: ubuntu-22.04
           - python-version: "3.8"


### PR DESCRIPTION
Bump to use newer ubuntu-24.04 rather than ubuntu-20.04 for running tests for Python 3.6