### PR TITLE
style: changes ruff target python version to 3.7

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -3,7 +3,7 @@
 
 line-length = 120
 
-target-version = "py38"
+target-version = "py37"
 
 lint.pydocstyle.convention = "google"
 


### PR DESCRIPTION
Changes Ruff's target Python version to 3.7 to provide better backwards support