### PR TITLE
fix: removes end of line space for multiline comments with line breaks

### DIFF
--- a/add_header_comment/__main__.py
+++ b/add_header_comment/__main__.py
@@ -65,7 +65,7 @@ def add_header_comment(
             return "\n".join(lines)
         else:
             line_prefix = comment_prefix + " " if comment_prefix else ""
-            return line_prefix + line
+            return (line_prefix + line).rstrip()
 
     # creates header comment string
     header_comment = ""

--- a/tests/header-multiline-with-line-breaks.txt
+++ b/tests/header-multiline-with-line-breaks.txt
@@ -1,0 +1,5 @@
+Hello, this header has multiple lines. This is a very long header paragraph. It has multiple sentences. Please find more documentation at
+
+  https://github.com/sayari-analytics/add-header-comment
+
+This another follow up sentence. This is sort of like the format of the Apache License 2.0. There is a paragraph in the beginning and a paragraph at the end with a URL in the middle.

--- a/tests/python-multiline-with-line-breaks/expected.py
+++ b/tests/python-multiline-with-line-breaks/expected.py
@@ -1,0 +1,8 @@
+# Hello, this header has multiple lines. This is a very long header paragraph. It has multiple sentences. Please find more documentation at
+#
+#   https://github.com/sayari-analytics/add-header-comment
+#
+# This another follow up sentence. This is sort of like the format of the Apache License 2.0. There is a paragraph in the beginning and a paragraph at the end with a URL in the middle.
+"""This is an example with a docstring header."""
+
+print("hello world")

--- a/tests/python-multiline-with-line-breaks/input.py
+++ b/tests/python-multiline-with-line-breaks/input.py
@@ -1,0 +1,3 @@
+"""This is an example with a docstring header."""
+
+print("hello world")

--- a/tests/python-multiline-with-line-breaks/test.sh
+++ b/tests/python-multiline-with-line-breaks/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -euo pipefail
+
+coverage run --append add_header_comment \
+  --header-filepath tests/header-multiline-with-line-breaks.txt \
+  "$@"


### PR DESCRIPTION
fix: removes end of line space for multiline comments with line breaks