### PR TITLE
chore: supply-chain hardening — lockfile enforcement + action SHA pins

### DIFF
--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -12,23 +12,26 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build
+          uv pip install build --exclude-newer $(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ)
 
       - name: Build package
         run: python -m build
 
       - name: Publish distribution Package to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -19,11 +19,14 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.8"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
 
       - name: Get exact python version
         id: python-version
@@ -31,7 +34,7 @@ jobs:
           echo "python_version=$(python --version)" >> $GITHUB_ENV
 
       - name: Cache pre-commit environment
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         id: cache-pre-commit
         with:
           path: |
@@ -45,7 +48,7 @@ jobs:
           python -m venv venv
           source venv/bin/activate
           pip install --upgrade pip
-          pip install pre-commit
+          uv pip install pre-commit --exclude-newer $(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ)
 
       - name: Run Style Check
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,11 +42,11 @@ jobs:
             runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python ${{ matrix.python-version }}
         if: ${{ !matrix.image }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install uv
+        if: ${{ !matrix.image }}
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+
       - name: Test without docker
         if: ${{ !matrix.image }}
         run: ./install-and-run-tests.sh
@@ -70,3 +74,4 @@ jobs:
 
       - name: Check if coverage is 100%
         run: grep "100%" coverage.log
+

--- a/install-and-run-tests.sh
+++ b/install-and-run-tests.sh
@@ -4,11 +4,12 @@ set -euo pipefail
 
 set -x
 
-pip install -r requirements/test.txt
-pip install -e .
+uv pip install --system -r requirements/test.txt --exclude-newer $(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ)
+uv pip install --system -e . --exclude-newer $(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ)
 
 set +x
 
 ./run-tests.sh
 
 coverage report -m | tee coverage.log
+


### PR DESCRIPTION
## Supply Chain Hardening

Automated supply-chain security controls applied by `supply-chain-pr.py`.

### Changes made

- **`publish_package.yml`**: SHA-pinned 3 actions to full commit hash
- **`style.yml`**: SHA-pinned 3 actions to full commit hash
- **`test.yml`**: SHA-pinned 2 actions to full commit hash

### Python ecosystem changes

- **`publish_package.yml`**: pip install build → uv pip install (+ cooldown)
- **`publish_package.yml`**: astral-sh/setup-uv@v5 step injected
- **`style.yml`**: pip install pre-commit → uv pip install (+ cooldown)
- **`style.yml`**: astral-sh/setup-uv@v5 step injected

> **Migration note**: `pip install` has been replaced with `uv pip sync --exclude-newer` as an immediate security shim. Full migration to a `uv`-managed lockfile (`uv lock` + `uv sync --frozen`) is recommended as a follow-up for stronger supply-chain guarantees.

### Why these controls

| Control | Threat mitigated |
|---------|-----------------|
| Action SHA pins | Prevents tag-hijack (ref: aquasecurity/trivy-action, Mar 2026) |
| `UV_EXCLUDE_NEWER` / `renovate.json` cooldown | 7-day PyPI cooldown prevents same-day version compromise |
| `uv sync --frozen` / `poetry install --no-update` | CI installs exact lockfile versions — no silent drift |

### Testing checklist

- [ ] CI passes on this branch (green)
- [ ] Python install/sync step succeeds with no version changes

---
*Generated by `supply-chain-pr.py` — part of the dependency-security-policy rollout.*