### PR TITLE
ci: pin actions to exact sha hash and adds pre-commit checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,5 @@ updates:
       interval: "daily"
     commit-message:
       prefix: ci
+    cooldown:
+      default-days: 7

--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -10,9 +10,13 @@ jobs:
   publish-package:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -12,10 +12,10 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.12'
 
@@ -28,7 +28,7 @@ jobs:
         run: python -m build
 
       - name: Publish distribution Package to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -19,11 +19,11 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.8"
+          python-version: "3.10"
 
       - name: Get exact python version
         id: python-version
@@ -31,7 +31,7 @@ jobs:
           echo "python_version=$(python --version)" >> $GITHUB_ENV
 
       - name: Cache pre-commit environment
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: cache-pre-commit
         with:
           path: |

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -17,9 +17,13 @@ jobs:
     name: Style
     runs-on: ubuntu-24.04
     timeout-minutes: 60
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,11 +42,11 @@ jobs:
             runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python ${{ matrix.python-version }}
         if: ${{ !matrix.image }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,8 @@ jobs:
     name: Test
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 60
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false
@@ -43,6 +45,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
         if: ${{ !matrix.image }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,18 +11,18 @@ repos:
       - id: check-shebang-scripts-are-executable
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.37.0
+    rev: 0.37.1
     hooks:
       - id: check-dependabot
       - id: check-github-workflows
 
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.23.1
+    rev: v1.24.1
     hooks:
       - id: zizmor
         args:
           - --fix=safe  # change to unsafe-only to enable unsafe fixes
-          - --min-severity=high
+          - --min-severity=medium
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.7.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,20 @@ repos:
       - id: requirements-txt-fixer
       - id: check-shebang-scripts-are-executable
 
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.37.0
+    hooks:
+      - id: check-dependabot
+      - id: check-github-workflows
+
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.23.1
+    hooks:
+      - id: zizmor
+        args:
+          - --fix=safe  # change to unsafe-only to enable unsafe fixes
+          - --min-severity=high
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.7.1
     hooks:

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,3 @@
+rules:
+  cache-poisoning:
+    disable: true

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,3 +1,0 @@
-rules:
-  cache-poisoning:
-    disable: true


### PR DESCRIPTION
Pins actions to exact sha hash using pinact: https://github.com/suzuki-shunsuke/pinact
 - requested from this pr: https://github.com/sayari-analytics/add-header-comment/pull/9

Adds jsonschema (github actions/dependabot) and zizmor pre-commit checks

Bumps pre-commit check to use Python 3.10