### PR TITLE
style: sets zizmor to always run in offline mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,7 @@ repos:
     hooks:
       - id: zizmor
         args:
+          - --offline
           - --fix=safe  # change to unsafe-only to enable unsafe fixes
           - --min-severity=medium
 


### PR DESCRIPTION
zizmor can optionally run in online mode if provided a GitHub token: https://docs.zizmor.sh/usage/#operating-modes

In the GitHub actions, the pre-commit checks already run in offline mode because a GitHub token isn't provided. However, if we are running in GitHub Codespaces, a GitHub token is present. Since we want to match the checks run in Codespaces as in the GItHub Actions, we should explicitly pass the offline flag.